### PR TITLE
Stop receiver application when disconnecting.

### DIFF
--- a/chromecastjs.js
+++ b/chromecastjs.js
@@ -91,7 +91,7 @@ var ChromecastJS = function(scope, reciever) {
         }
     }
     ChromecastJS.prototype.disconnect = function() {
-        cast.framework.CastContext.getInstance().endCurrentSession()
+        cast.framework.CastContext.getInstance().endCurrentSession(true)
     }
     // Check if a chromecast is available, trigger 'Init' event
     var castInterval = setInterval(function() {


### PR DESCRIPTION
If we don't stop the receiver application, the disconnection seems
to leave the chromecast is a sort of dangling state where it is
unable to start another session immediately. The official
documentation for endCurrentSession is, unfortunately, terse. [0]
I do this to reproduce the problem:

- Go to https://fenny.github.io/ChromecastJS/demo/index.html.
- Click "Cast media to chromecast" and select my chromecast from menu.
- Click "Disconnect" button after playback start.
- Click "Cast media to chromecast" again and select my chromecast from
  menu.
Playback doesn't start. I see this error in console:

    chromecastjs.js:197 Uncaught TypeError: Cannot read property 'activeTrackIds' of undefined
        at chromecastjs.js:197
    (anonymous) @ chromecastjs.js:197
    setTimeout (async)
    IsConnectedChanged @ chromecastjs.js:165
    (anonymous) @ cast_framework.js:39
    S.dispatchEvent @ cast_framework.js:39
    set @ cast_framework.js:61
    f.Rb @ cast_framework.js:62
    (anonymous) @ cast_framework.js:39
    S.dispatchEvent @ cast_framework.js:39
    V @ cast_framework.js:52
    f.Za @ cast_framework.js:49
    (anonymous) @ cast_framework.js:47
    V.onMessage @ cast_sender.js:85
    S.i @ cast_sender.js:65

which tells me that the device hasn't been properly initialized.

To confirm that my fix actually solves the above problem, I edited the
chromecastjs.js script in Chrome Dev Tool and tested that I can't
reproduce the dangling state anymore.

[0] https://developers.google.com/cast/docs/reference/chrome/cast.framework.CastContext#endCurrentSession